### PR TITLE
Creation error handling

### DIFF
--- a/flask_dynamo/errors.py
+++ b/flask_dynamo/errors.py
@@ -7,3 +7,10 @@ class ConfigurationError(Exception):
     Flask-Dynamo.
     """
     pass
+
+
+class DynamodbTableError(Exception):
+    """
+    This exception is raised if tables already exists or can't be updated.
+    """
+    pass


### PR DESCRIPTION
Hello,

I added few things in this PR:

* I had a python3 compatibility issue with `dict.iteritems()`. Now python3 use `dict.items()`
* I had a problem with table creation : 
```
with application.app_context():
     application.config['DYNAMODB'].create_all()
```
This created my tables the first time, then raise an error the next times. I need to let the creation occurs at each launch if they aren't exist. The problem with the actual code is if I want to modify the throughput of my table, there's no automagical modification and if I add a table, the first exception will exit the loop without creating the other tables.

So I modified the behavior of the create function : it will try to create a new table. If it fails, it will try an update on it. If the fields remains the same, Dynamodb API will raise a 400 error which is catched and add the table name to a list of failed tables. It will continue to create/update other tables and will raise a custom exception named : `DynamoTableError` at the end of the loop if there's failed tables.

On my main code I can now use : 
```
with application.app_context():
    try:
        application.config['DYNAMODB'].create_all()
    except DynamodbTableError as e:
        application.logger.info(e)
```

What do you think about it ?

Thanks for your work

