### PR TITLE
Update flask dynamo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,99 @@
-*.egg-info
-dist
-docs/_build
-build
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
 python:
-  - '2.7'
-  - 'pypy'
+- '2.7'
+- '3.3'
+- '3.4'
+- '3.5'
+- pypy
 install:
-  - pip install -r requirements.txt
-  - python setup.py develop
+- pip install -r requirements.txt
+- python setup.py develop
 script:
-  - python setup.py test
-  - cd docs && make html
+- python setup.py test
+- cd docs && make html
 env:
   global:
-  - secure: "Lt0DLSvIV2lzul1Z3/eusQ5WMUlUqWQPNclELkN+Dtn51KAm105ZuLJMjyCb5Aq/Fr1plKTEJm+faeyIX2PkmnxUYcfXsFuG4SfM+SZzPPfXndWuPqaa+k/LkcTAtwm/WBtvFmBjwumUhLGdQgDIE9mmQ7TBiF8zt89ySQCejb4="
-  - secure: "EYmpcJVxQmlrbZOrKHq4mKBQSsBuaISEVb/UMe55TbcbunfT+vkXgycX1xF2MYBBVvDpKv2F5pK9z2YHA3IS4QhscdC1aVkYhnM86VD1IdWq1lbhgL4hjoFwg4uBZGCOBArua5dVXC/7fnyaF0vtBMmQRavgrW16zBGBdvRBmcA="
+  - secure: hOHQ0Tqh7h2VlAJswYcRV7YV2HDxnwaq0Sdom61/qlF+oyxaMTSuYGJdGG+981DHyYFkxLX97yWcvs39UlpgWBCJN7obkdgy6kR3FZDraAVdgrBAEBYjE9fhla0Mw4PgCxr4t1dI82iUkg5u0CPF26a1ZgqlCvcskfNnjnXJXfY=
+  - secure: RQn/pmT+4MpB2aeL+63XwshftbSm+j28d/diHnUqUhr/JKXwoV9xoRLgZmTHJQzMVuaCYxaFxjfJsimVPxX1GZJm6J6vl6suNDve8GohirrRXjexmqqnQW3f+0btieOQjXmawI9YVd9m5D8t0+twE7r8kRExAztt2lHM9SFQ+Qg=

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@
 API
 ===
 
-.. module:: flask.ext.dynamo.manager
+.. module:: flask_dynamo.manager
 
 This part of the documentation documents all the public classes, functions, and
 API details in flask-dynamo.  This documentation is auto generated, and is
@@ -17,10 +17,19 @@ Configuration
 .. autoclass:: Dynamo
 
     .. automethod:: init_app
-    .. automethod:: init_settings
-    .. automethod:: check_settings
     .. autoattribute:: connection
-    .. autoattribute:: tables
+    .. autoinstanceattribute:: DynamoLazyTables
+    .. automethod:: get_table
+    .. automethod:: create_all
+    .. automethod:: destroy_all
+
+.. autoclass:: DynamoLazyTables
+
+    .. automethod:: keys
+    .. automethod:: len
+    .. automethod:: items
+    .. automethod:: wait_exists
+    .. automethod:: wait_not_exists
     .. automethod:: create_all
     .. automethod:: destroy_all
 
@@ -28,6 +37,6 @@ Configuration
 Errors
 ------
 
-.. module:: flask.ext.dynamo.errors
+.. module:: flask_dynamo.errors
 
 .. autoclass:: ConfigurationError

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 from os.path import abspath
 from sys import path
 
-from flask.ext.dynamo import __version__ as version
+from flask_dynamo import __version__ as version
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -68,24 +68,29 @@ Below is an example::
 
     # app.py
 
-
-    from boto.dynamodb2.fields import HashKey
-    from boto.dynamodb2.table import Table
-
     from flask import Flask
     from flask.ext.dynamo import Dynamo
 
     app = Flask(__name__)
     app.config['DYNAMO_TABLES'] = [
-        Table('users', schema=[HashKey('username')]),
-        Table('groups', schema=[HashKey('name')]),
-    ]
+        {
+             TableName='users',
+             KeySchema=[dict(AttributeName='username', KeyType='HASH')],
+             AttributeDefinitions=[dict(AttributeName='username', AttributeType='S')],
+             ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
+        }, {
+             TableName='groups',
+             KeySchema=[dict(AttributeName='name', KeyType='HASH')],
+             AttributeDefinitions=[dict(AttributeName='name', AttributeType='S')],
+             ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
+        }
+     ]
 
 In the above example, I'm defining two DynamoDB tables: ``users`` and
 ``groups``, along with their respective schemas.
 
 flask-dynamo will respect *any* boto tables you define -- it will also respect
-any of the other fields you specify on your tables.
+any of the other fields you specify on your tables
 
 
 Initialize Dynamo
@@ -98,17 +103,22 @@ All you need to do is pass your app to the ``Dynamo`` constructor::
 
     # app.py
 
-
-    from boto.dynamodb2.fields import HashKey
-    from boto.dynamodb2.table import Table
-
     from flask import Flask
     from flask.ext.dynamo import Dynamo
 
     app = Flask(__name__)
     app.config['DYNAMO_TABLES'] = [
-        Table('users', schema=[HashKey('username')]),
-        Table('groups', schema=[HashKey('name')]),
+        {
+             TableName='users',
+             KeySchema=[dict(AttributeName='username', KeyType='HASH')],
+             AttributeDefinitions=[dict(AttributeName='username', AttributeType='S')],
+             ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
+        }, {
+             TableName='groups',
+             KeySchema=[dict(AttributeName='name', KeyType='HASH')],
+             AttributeDefinitions=[dict(AttributeName='name', AttributeType='S')],
+             ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
+        }
     ]
 
     dynamo = Dynamo(app)
@@ -225,5 +235,5 @@ No other code needs to be changed in order to use DynamoDB Local.
 .. _pip: http://pip.readthedocs.org/en/latest/
 .. _AWS Console: https://console.aws.amazon.com/iam/home?#security_credential
 .. _StackOverflow question: http://stackoverflow.com/questions/5971312/how-to-set-environment-variables-in-python
-.. _boto DynamoDB tutorial: http://boto.readthedocs.org/en/latest/dynamodb2_tut.html
+.. _boto DynamoDB tutorial: http://boto3.readthedocs.io/en/latest/guide/dynamodb.html
 .. _DynamoDB Local documentation: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -90,7 +90,7 @@ In the above example, I'm defining two DynamoDB tables: ``users`` and
 ``groups``, along with their respective schemas.
 
 flask-dynamo will respect *any* boto tables you define -- it will also respect
-any of the other fields you specify on your tables
+any of the other fields you specify on your tables.
 
 
 Initialize Dynamo

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,9 +1,10 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.7'
+__version__ = '0.1.0'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 
 
 from .manager import Dynamo
+from .errors import ConfigurationError

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -8,8 +8,57 @@ from flask import current_app
 from .errors import ConfigurationError
 
 
+class DynamoLazyTables(object):
+    """Manages access to Dynamo Tables."""
+    def __init__(self, connection, table_config):
+        self._table_config = table_config
+        self._connection = connection
+
+    def __getitem__(self, name):
+        """Get the connection for a table by name."""
+        return self._connection.Table(name)
+
+    def keys(self):
+        """The table names in our config."""
+        return [t['TableName'] for t in self._table_config]
+
+    def len(self):
+        """The number of tables we are configured for."""
+        return len(self.keys())
+
+    def items(self):
+        """The table tuples (name, connection.Table())."""
+        for table_name in self.keys():
+            yield (table_name, self[table_name])
+
+    def _wait(self, table_name, type_waiter):
+        waiter = self._connection.meta.client.get_waiter(type_waiter)
+        waiter.wait(TableName=table_name)
+
+    def wait_exists(self, table_name):
+        self._wait(table_name, 'table_exists')
+
+    def wait_not_exists(self, table_name):
+        self._wait(table_name, 'table_not_exists')
+
+    def create_all(self, wait=False):
+        for table in self._table_config:
+            self._connection.create_table(**table)
+        if wait:
+            for table in self._table_config:
+                self.wait_exists(table['TableName'])
+
+    def destroy_all(self, wait=False):
+        for table in self._table_config:
+            table = self._connection.Table(table['TableName'])
+            table.delete()
+        if wait:
+            for table in self._table_config:
+                self.wait_not_exists(table['TableName'])
+
+
 class Dynamo(object):
-    """DynamoDB wrapper for Flask."""
+    """DynamoDB engine manager."""
 
     DEFAULT_REGION = 'us-east-1'
 
@@ -30,13 +79,15 @@ class Dynamo(object):
         :param obj app: The Flask application.
         """
 
-        self.init_settings(app)
-        self.check_settings(app)
+        self._init_settings(app)
+        self._check_settings(app)
 
         app.extensions['dynamo'] = self
 
+        self.tables = DynamoLazyTables(self.connection, app.config['DYNAMO_TABLES'])
+
     @staticmethod
-    def init_settings(app):
+    def _init_settings(app):
         """Initialize all of the extension settings."""
         app.config.setdefault('DYNAMO_TABLES', [])
         app.config.setdefault('DYNAMO_ENABLE_LOCAL', environ.get('DYNAMO_ENABLE_LOCAL', False))
@@ -47,7 +98,7 @@ class Dynamo(object):
         app.config.setdefault('AWS_REGION', environ.get('AWS_REGION', Dynamo.DEFAULT_REGION))
 
     @staticmethod
-    def check_settings(app):
+    def _check_settings(app):
         """
         Check all user-specified settings to ensure they're correct.
 
@@ -64,7 +115,7 @@ class Dynamo(object):
         if app.config['DYNAMO_ENABLE_LOCAL'] and not (app.config['DYNAMO_LOCAL_HOST'] and app.config['DYNAMO_LOCAL_PORT']):
             raise ConfigurationError('If you have enabled Dynamo local, you must specify the host and port.')
 
-    def get_app(self):
+    def _get_app(self):
         """
         Helper method that implements the logic to look up an application.
         pass
@@ -76,14 +127,14 @@ class Dynamo(object):
             return self.app
 
         raise RuntimeError(
-            'application not registered on db instance and no application'
+            'application not registered on dynamo instance and no application'
             'bound to current context'
         )
 
     @staticmethod
-    def get_state(app):
+    def _get_ctx(app):
         """
-        Gets the state for the application
+        Gets the dyanmo app context state.
         """
 
         try:
@@ -101,77 +152,37 @@ class Dynamo(object):
         This will be lazily created if this is the first time this is being
         accessed.  This connection is reused for performance.
         """
-        app = self.get_app()
-        ctx = self.get_state(app)
-        if ctx is not None:
-            if not hasattr(ctx, 'dynamo_connection'):
-                session_kwargs = {}
-                client_kwargs = {}
-                local = True if app.config['DYNAMO_ENABLE_LOCAL'] else False
-                if local:
-                    client_kwargs['endpoint_url'] = 'http://{}:{}'.format(
-                        app.config['DYNAMO_LOCAL_HOST'],
-                        app.config['DYNAMO_LOCAL_PORT'],
-                    )
-
-                # Only apply if manually specified: otherwise, we'll let boto
-                # figure it out (boto will sniff for ec2 instance profile
-                # credentials).
-                if app.config['AWS_ACCESS_KEY_ID']:
-                    session_kwargs['aws_access_key_id'] = app.config['AWS_ACCESS_KEY_ID']
-                if app.config['AWS_SECRET_ACCESS_KEY']:
-                    session_kwargs['aws_secret_access_key'] = app.config['AWS_SECRET_ACCESS_KEY']
-                if app.config.get('AWS_REGION', None):
-                    session_kwargs['region_name'] = app.config['AWS_REGION']
-
-                ctx.dynamo_session = Session(**session_kwargs)
-                ctx.dynamo_connection = ctx.dynamo_session.resource('dynamodb', **client_kwargs)
-
-            return ctx.dynamo_connection
-
-    @property
-    def tables(self):
-        """
-        Our DynamoDB tables.
-
-        These will be lazily initializes if this is the first time the tables
-        are being accessed.
-        """
-        app = self.get_app()
-        ctx = self.get_state(app)
-        if ctx is not None:
-            if not hasattr(ctx, 'dynamo_tables'):
-                ctx.dynamo_tables = {}
-                for table in app.config['DYNAMO_TABLES']:
-                    table_name = table['TableName']
-                    ctx.dynamo_tables[table_name] = table
-
-                    if not hasattr(ctx, 'dynamo_table_%s' % table_name):
-                        setattr(ctx, 'dynamo_table_%s' % table_name, table)
-
-            return ctx.dynamo_tables
-
-    def __getattr__(self, name):
-        """
-        Override the get attribute built-in method.
-
-        This will allow us to provide a simple table API.  Let's say a user
-        defines two tables: `users` and `groups`.  In this case, our
-        customization here will allow the user to access these tables by
-        calling `dynamo.users` and `dynamo.groups`, respectively.
-
-        :param str name: The DynamoDB table name.
-        :rtype: object
-        :returns: A Table object if the table was found.
-        :raises: AttributeError on error.
-        """
+        app = self._get_app()
+        ctx = self._get_ctx(app)
         try:
-            return self.tables[name]
-        except KeyError:
-            raise AttributeError('No table named %s found.' % name)
+            return ctx._connection
+        except AttributeError:
+            session_kwargs = {}
+            client_kwargs = {}
+            local = True if app.config['DYNAMO_ENABLE_LOCAL'] else False
+            if local:
+                client_kwargs['endpoint_url'] = 'http://{}:{}'.format(
+                    app.config['DYNAMO_LOCAL_HOST'],
+                    app.config['DYNAMO_LOCAL_PORT'],
+                )
+
+            # Only apply if manually specified: otherwise, we'll let boto
+            # figure it out (boto will sniff for ec2 instance profile
+            # credentials).
+            if app.config['AWS_ACCESS_KEY_ID']:
+                session_kwargs['aws_access_key_id'] = app.config['AWS_ACCESS_KEY_ID']
+            if app.config['AWS_SECRET_ACCESS_KEY']:
+                session_kwargs['aws_secret_access_key'] = app.config['AWS_SECRET_ACCESS_KEY']
+            if app.config.get('AWS_REGION', None):
+                session_kwargs['region_name'] = app.config['AWS_REGION']
+
+            ctx._session = Session(**session_kwargs)
+            ctx._connection = ctx._session.resource('dynamodb', **client_kwargs)
+
+            return ctx._connection
 
     def get_table(self, table_name):
-        return self.connection.Table(table_name)
+        return self.tables[table_name]
 
     def create_all(self, wait=False):
         """
@@ -180,12 +191,7 @@ class Dynamo(object):
         We'll ignore table(s) that already exists.
         We'll error out if the tables can't be created for some reason.
         """
-        for table_name in self.tables:
-            table = self.tables[table_name]
-            self.connection.create_table(**table)
-            if wait:
-                waiter = self.connection.meta.client.get_waiter('table_exists')
-                waiter.wait(TableName=table['TableName'])
+        self.tables.create_all(wait=wait)
 
     def destroy_all(self, wait=False):
         """
@@ -193,9 +199,4 @@ class Dynamo(object):
 
         We'll error out if the tables can't be destroyed for some reason.
         """
-        for table_name in self.tables:
-            table = self.connection.Table(table_name)
-            table.delete()
-            if wait:
-                waiter = self.connection.meta.client.get_waiter('table_not_exists')
-                waiter.wait(TableName=table['TableName'])
+        self.tables.destroy_all(wait=wait)

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -3,8 +3,7 @@
 
 from os import environ
 
-from boto.dynamodb2 import connect_to_region
-from boto.dynamodb2.table import Table
+from boto3.session import Session
 from flask import (
     _app_ctx_stack as stack,
 )
@@ -75,27 +74,27 @@ class Dynamo(object):
         ctx = stack.top
         if ctx is not None:
             if not hasattr(ctx, 'dynamo_connection'):
-                kwargs = {
-                    'host': self.app.config['DYNAMO_LOCAL_HOST'] if self.app.config['DYNAMO_ENABLE_LOCAL'] else None,
-                    'port': int(self.app.config['DYNAMO_LOCAL_PORT']) if self.app.config['DYNAMO_ENABLE_LOCAL'] else None,
-                    'is_secure': False if self.app.config['DYNAMO_ENABLE_LOCAL'] else True,
-                }
+                session_kwargs = {}
+                client_kwargs = {}
+                local = True if self.app.config['DYNAMO_ENABLE_LOCAL'] else False
+                if local:
+                    client_kwargs['endpoint_url'] = 'http://{}:{}'.format(
+                        self.app.config['DYNAMO_LOCAL_HOST'],
+                        self.app.config['DYNAMO_LOCAL_PORT'],
+                    )
 
                 # Only apply if manually specified: otherwise, we'll let boto
                 # figure it out (boto will sniff for ec2 instance profile
                 # credentials).
                 if self.app.config['AWS_ACCESS_KEY_ID']:
-                  kwargs['aws_access_key_id'] = self.app.config['AWS_ACCESS_KEY_ID']
+                    session_kwargs['aws_access_key_id'] = self.app.config['AWS_ACCESS_KEY_ID']
                 if self.app.config['AWS_SECRET_ACCESS_KEY']:
-                  kwargs['aws_secret_access_key'] = self.app.config['AWS_SECRET_ACCESS_KEY']
+                    session_kwargs['aws_secret_access_key'] = self.app.config['AWS_SECRET_ACCESS_KEY']
+                if self.app.config.get('AWS_REGION', None):
+                    session_kwargs['region_name'] = self.app.config['AWS_REGION']
 
-                # If DynamoDB local is disabled, we'll remove these settings.
-                if not kwargs['host']:
-                    del kwargs['host']
-                if not kwargs['port']:
-                    del kwargs['port']
-
-                ctx.dynamo_connection = connect_to_region(self.app.config['AWS_REGION'], **kwargs)
+                ctx.dynamo_session = Session(**session_kwargs)
+                ctx.dynamo_connection = ctx.dynamo_session.resource('dynamodb', **client_kwargs)
 
             return ctx.dynamo_connection
 
@@ -112,11 +111,11 @@ class Dynamo(object):
             if not hasattr(ctx, 'dynamo_tables'):
                 ctx.dynamo_tables = {}
                 for table in self.app.config['DYNAMO_TABLES']:
-                    table.connection = self.connection
-                    ctx.dynamo_tables[table.table_name] = table
+                    table_name = table['TableName']
+                    ctx.dynamo_tables[table_name] = table
 
-                    if not hasattr(ctx, 'dynamo_table_%s' % table.table_name):
-                        setattr(ctx, 'dynamo_table_%s' % table.table_name, table)
+                    if not hasattr(ctx, 'dynamo_table_%s' % table_name):
+                        setattr(ctx, 'dynamo_table_%s' % table_name, table)
 
             return ctx.dynamo_tables
 
@@ -135,36 +134,36 @@ class Dynamo(object):
         :raises: AttributeError on error.
         """
         if name in self.tables:
-            return self.tables[name]
+            return self.get_table(name)
 
         raise AttributeError('No table named %s found.' % name)
 
-    def create_all(self):
+    def get_table(self, table_name):
+        return self.connection.Table(table_name)
+
+    def create_all(self, wait=False):
         """
         Create all user-specified DynamoDB tables.
 
         We'll ignore table(s) that already exists.
         We'll error out if the tables can't be created for some reason.
         """
-        for table_name, table in self.tables.iteritems():
+        for table_name in self.tables:
+            table = self.tables[table_name]
+            self.connection.create_table(**table)
+            if wait:
+                waiter = self.connection.meta.client.get_waiter('table_exists')
+                waiter.wait(TableName=table['TableName'])
 
-            if self.tables.get(table_name):
-                continue
-
-            Table.create(
-                table_name = table.table_name,
-                schema = table.schema,
-                throughput = table.throughput,
-                indexes = table.indexes,
-                global_indexes = table.global_indexes,
-                connection = self.connection,
-            )
-
-    def destroy_all(self):
+    def destroy_all(self, wait=False):
         """
         Destroy all user-specified DynamoDB tables.
 
         We'll error out if the tables can't be destroyed for some reason.
         """
-        for table_name, table in self.tables.iteritems():
+        for table_name in self.tables:
+            table = self.connection.Table(table_name)
             table.delete()
+            if wait:
+                waiter = self.connection.meta.client.get_waiter('table_not_exists')
+                waiter.wait(TableName=table['TableName'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask>=0.10.1
 Sphinx==1.2.2
-boto>=2.29.1
-pytest==2.5.2
+boto3>=1.1.4
+pytest>=2.5.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.7'
+VERSION = '0.1.0'
 
 
 class RunTests(Command):
@@ -32,8 +32,9 @@ class RunTests(Command):
 
     def run(self):
         """Run all tests!"""
-        errno = call(['py.test'])
-        raise SystemExit(errno)
+        import sys
+        import py.test
+        raise SystemExit(py.test.main(args=[]))
 
 
 setup(
@@ -48,7 +49,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['boto>=2.29.1', 'Flask>=0.10.1'],
+    install_requires = ['boto3>=1.1.4', 'Flask>=0.10.1'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',
@@ -73,6 +74,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,12 +3,10 @@ from __future__ import print_function
 
 
 from os import environ
-from time import sleep
-from unittest import TestCase
 from uuid import uuid4
 
 import pytest
-from flask import Flask
+from flask import Flask, current_app
 from flask.ext.dynamo import Dynamo, ConfigurationError
 
 def make_table(table_name, name, _type):
@@ -96,4 +94,4 @@ def test_tables(app, active_dynamo):
 def test_table_access(active_dynamo, app):
     with app.app_context():
         for table_name, table in active_dynamo.tables.items():
-            assert getattr(active_dynamo, table_name).name == table_name
+            assert getattr(active_dynamo, table_name)['TableName'] == table_name

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 from flask import Flask, current_app
-from flask.ext.dynamo import Dynamo, ConfigurationError
+from flask_dynamo import Dynamo, ConfigurationError
 
 def make_table(table_name, name, _type):
     return dict(
@@ -87,11 +87,9 @@ def test_connection(app, dynamo):
         assert hasattr(dynamo.connection, 'meta')
         assert hasattr(dynamo.connection.meta, 'client')
 
-def test_tables(app, active_dynamo):
-    with app.app_context():
-        assert len(active_dynamo.tables.keys()) == 2
-
 def test_table_access(active_dynamo, app):
     with app.app_context():
+        assert len(active_dynamo.tables.keys()) == 2
         for table_name, table in active_dynamo.tables.items():
-            assert getattr(active_dynamo, table_name)['TableName'] == table_name
+            assert active_dynamo.tables[table_name].name == table_name
+            assert current_app.extensions['dynamo'].tables[table_name].name == table_name


### PR DESCRIPTION
There is a lot in here:
1) support app factory and traditional method
2) refactoring of tables to a table manager object. This was to avoid messiness in circular references
3) breaking change: dynamo.table_name no longer supported. The __getattr__ would not play nice at all on python3. For now, i dropped support for this feature, but if you know of a way to reincorporate, I am more than happy to try and include it.
4) merge conflicts between the dev branch and the current master were resolved
5) github .gitignore file now included (there were python3 files that were not being ignored)
6) docs updated to match boto3, as well as updated apis.

This might be too much for one PR, and if that is the case, let me know and I will break it up.