### PR TITLE
Merge develop into master, bump to 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,99 @@
-*.egg-info
-dist
-docs/_build
-build
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - '2.7'
 - '3.4'
+- '3.5'
 - pypy
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.3'
 - '3.4'
 - '3.5'
 - pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ script:
 - cd docs && make html
 env:
   global:
-  - secure: hOHQ0Tqh7h2VlAJswYcRV7YV2HDxnwaq0Sdom61/qlF+oyxaMTSuYGJdGG+981DHyYFkxLX97yWcvs39UlpgWBCJN7obkdgy6kR3FZDraAVdgrBAEBYjE9fhla0Mw4PgCxr4t1dI82iUkg5u0CPF26a1ZgqlCvcskfNnjnXJXfY=
-  - secure: RQn/pmT+4MpB2aeL+63XwshftbSm+j28d/diHnUqUhr/JKXwoV9xoRLgZmTHJQzMVuaCYxaFxjfJsimVPxX1GZJm6J6vl6suNDve8GohirrRXjexmqqnQW3f+0btieOQjXmawI9YVd9m5D8t0+twE7r8kRExAztt2lHM9SFQ+Qg=
+  - secure: QktJb8B+STvIhcKu4oCG2f0W5IqzHkQVPP4uE5nxCZw64tKTRGhiHmtofxRMDqKl6ORlc9dSn8yHpyR4kCwDXSGYiOJi3jnI2bKz7DoqiKry5y+/PaUvJhYuVKfirTr2F5Wwzi1c06Zm7jQ1EpRqMe8qiZaqw1G5JGRDwnpqzoA=
+  - secure: V5HoVHPokoTRfpZstIn/O542w4dStXnAUwxSMTl1EzyaBMqONvBiW28Xkbxh5XekLa3NumoZKh9ZZQ7WwNXO00pmieNeYLXcWByztF937ozsraBHhmTnVvK59O4IkxlVy/jlxHrtIcRMdzXuIyubOppzYVUSc/rP+sbXXI4314Y=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - pypy
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - '2.7'
+  - '3.4'
   - 'pypy'
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 python:
-  - '2.7'
-  - '3.4'
-  - 'pypy'
+- '2.7'
+- '3.4'
+- pypy
 install:
-  - pip install -r requirements.txt
-  - python setup.py develop
+- pip install -r requirements.txt
+- python setup.py develop
 script:
-  - python setup.py test
-  - cd docs && make html
+- python setup.py test
+- cd docs && make html
 env:
   global:
-  - secure: "Lt0DLSvIV2lzul1Z3/eusQ5WMUlUqWQPNclELkN+Dtn51KAm105ZuLJMjyCb5Aq/Fr1plKTEJm+faeyIX2PkmnxUYcfXsFuG4SfM+SZzPPfXndWuPqaa+k/LkcTAtwm/WBtvFmBjwumUhLGdQgDIE9mmQ7TBiF8zt89ySQCejb4="
-  - secure: "EYmpcJVxQmlrbZOrKHq4mKBQSsBuaISEVb/UMe55TbcbunfT+vkXgycX1xF2MYBBVvDpKv2F5pK9z2YHA3IS4QhscdC1aVkYhnM86VD1IdWq1lbhgL4hjoFwg4uBZGCOBArua5dVXC/7fnyaF0vtBMmQRavgrW16zBGBdvRBmcA="
+  - secure: hOHQ0Tqh7h2VlAJswYcRV7YV2HDxnwaq0Sdom61/qlF+oyxaMTSuYGJdGG+981DHyYFkxLX97yWcvs39UlpgWBCJN7obkdgy6kR3FZDraAVdgrBAEBYjE9fhla0Mw4PgCxr4t1dI82iUkg5u0CPF26a1ZgqlCvcskfNnjnXJXfY=
+  - secure: RQn/pmT+4MpB2aeL+63XwshftbSm+j28d/diHnUqUhr/JKXwoV9xoRLgZmTHJQzMVuaCYxaFxjfJsimVPxX1GZJm6J6vl6suNDve8GohirrRXjexmqqnQW3f+0btieOQjXmawI9YVd9m5D8t0+twE7r8kRExAztt2lHM9SFQ+Qg=

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@
 API
 ===
 
-.. module:: flask.ext.dynamo.manager
+.. module:: flask_dynamo.manager
 
 This part of the documentation documents all the public classes, functions, and
 API details in flask-dynamo.  This documentation is auto generated, and is
@@ -17,10 +17,19 @@ Configuration
 .. autoclass:: Dynamo
 
     .. automethod:: init_app
-    .. automethod:: init_settings
-    .. automethod:: check_settings
     .. autoattribute:: connection
-    .. autoattribute:: tables
+    .. autoinstanceattribute:: DynamoLazyTables
+    .. automethod:: get_table
+    .. automethod:: create_all
+    .. automethod:: destroy_all
+
+.. autoclass:: DynamoLazyTables
+
+    .. automethod:: keys
+    .. automethod:: len
+    .. automethod:: items
+    .. automethod:: wait_exists
+    .. automethod:: wait_not_exists
     .. automethod:: create_all
     .. automethod:: destroy_all
 
@@ -28,6 +37,6 @@ Configuration
 Errors
 ------
 
-.. module:: flask.ext.dynamo.errors
+.. module:: flask_dynamo.errors
 
 .. autoclass:: ConfigurationError

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,16 @@ Change Log
 All library changes, in descending order.
 
 
+Version 0.0.5
+-------------
+
+**Released on March 29, 2015.**
+
+- Merging PR for improved environment variable detection using boto.  We'll now
+  allow the user to configure Flask-Dynamo through all of the standard boto
+  methods.
+
+
 Version 0.0.4
 -------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,15 @@ Change Log
 All library changes, in descending order.
 
 
+Version 0.0.7
+-------------
+
+**Released on May 25, 2015.**
+
+- Fixing deferred initialization of app object.  Thanks `@jpanganiban
+  <https://github.com/jpanganiban>`_ for the fix!
+
+
 Version 0.0.6
 -------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,28 @@ Change Log
 
 All library changes, in descending order.
 
+Version 0.1.0
+-------------
+
+**Not yet released.**
+
+- Added support for flask app factory and traditional methods of initialization.
+- Added documentation for boto3.
+- Fixed reuse of dynamodb connections across requests.
+- Optimized tests to run faster.
+- Added support for AWS_SESSION_TOKEN.  Thanks `@vbisserie
+  <https://github.com/vbisserie>`_ for the code!
+
+
+Version 0.0.8
+-------------
+
+**Released on August 1, 2017.**
+
+- Improving the ``create_all`` management command so it won't error out when
+  attempting to re-create already created tables.  Thanks `@amir-beheshty
+  <https://github.com/amir-beheshty>`_ for the codez!
+
 
 Version 0.0.7
 -------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,15 @@ Change Log
 All library changes, in descending order.
 
 
+Version 0.0.6
+-------------
+
+**Released on March 29, 2015.**
+
+- Allowing users to specify ``DYNAMO_TABLES`` dynamically =)  This makes it
+  possible to specify your tables dynamically instead of immediately at startup.
+
+
 Version 0.0.5
 -------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,14 @@ Change Log
 All library changes, in descending order.
 
 
+Version 0.0.4
+-------------
+
+**Released on November 17, 2014.**
+
+- Adding support for DynamoDB Local!
+
+
 Version 0.0.3
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 from os.path import abspath
 from sys import path
 
-from flask.ext.dynamo import __version__ as version
+from flask_dynamo import __version__ as version
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -36,9 +36,12 @@ The required environment variables are:
 - ``AWS_ACCESS_KEY_ID`` (*your Amazon access key ID*)
 - ``AWS_SECRET_ACCESS_KEY`` (*your Amazon secret access key*)
 
-There is also an optional variable you can set:
+There are also optional variables you can set:
 
 - ``AWS_REGION`` (*defaults to us-east-1*)
+- ``DYNAMO_ENABLE_LOCAL`` (*defaults to False*)
+- ``DYNAMO_LOCAL_HOST`` (*defaults to None*)
+- ``DYNAMO_LOCAL_PORT`` (*defaults to None*)
 
 These credentials can be grabbed from your `AWS Console`_.
 
@@ -190,7 +193,37 @@ The below code snippet will destroy all of your predefined DynamoDB tables::
     completely destroy your application's data!
 
 
+Using DynamoDB Local
+--------------------
+
+If you'd like to use a local DynamoDB instance, flask-dynamo can help you.  The
+only change you need to make is to your configuration.  By specifying a few
+extra configuration variables, you'll be able to connect to your local DynamoDB
+instance as opposed to the 'real' AWS cloud service -- this is great for testing
+things out.
+
+For more information about DynamoDB local, read the official `DynamoDB Local
+documentation`_.
+
+The settings you need to set are:
+
+- ``DYNAMO_ENABLE_LOCAL`` - Set this to ``True``.
+- ``DYNAMO_LOCAL_HOST`` - Set this to your local DB hostname -- usually
+  ``'localhost'``.
+- ``DYNAMO_LOCAL_PORT`` - Set this to your local DB port -- usually ``8000``.
+
+The settings above can be specified in one of two ways, either via environment
+variables, or via application configuration options directly, eg:
+
+    app.config['DYNAMO_ENABLE_LOCAL'] = True
+    app.config['DYNAMO_LOCAL_HOST'] = 'localhost'
+    app.config['DYNAMO_LOCAL_PORT'] = 8000
+
+No other code needs to be changed in order to use DynamoDB Local.
+
+
 .. _pip: http://pip.readthedocs.org/en/latest/
 .. _AWS Console: https://console.aws.amazon.com/iam/home?#security_credential
 .. _StackOverflow question: http://stackoverflow.com/questions/5971312/how-to-set-environment-variables-in-python
 .. _boto DynamoDB tutorial: http://boto.readthedocs.org/en/latest/dynamodb2_tut.html
+.. _DynamoDB Local documentation: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,12 @@ This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
 
+Version 0.0.3 -> Version 0.0.4
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.2 -> Version 0.0.3
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,12 @@ This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
 
+Version 0.0.6 -> Version 0.0.7
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.5 -> Version 0.0.6
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,12 @@ This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
 
+Version 0.0.4 -> Version 0.0.5
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.3 -> Version 0.0.4
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,12 @@ This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
 
+Version 0.0.5 -> Version 0.0.6
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.4 -> Version 0.0.5
 ------------------------------
 

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,7 +1,7 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,9 +1,10 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.7'
+__version__ = '0.1.0'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 
 
 from .manager import Dynamo
+from .errors import ConfigurationError

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,7 +1,7 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,7 +1,7 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 

--- a/flask_dynamo/__init__.py
+++ b/flask_dynamo/__init__.py
@@ -1,7 +1,7 @@
 """Flask integration for DynamoDB."""
 
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 __author__ = 'Randall Degges'
 __email__ = 'r@rdegges.com'
 

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -74,11 +74,21 @@ class Dynamo(object):
         ctx = stack.top
         if ctx is not None:
             if not hasattr(ctx, 'dynamo_connection'):
-                ctx.dynamo_connection = connect_to_region(
-                    self.app.config['AWS_REGION'],
-                    aws_access_key_id = self.app.config['AWS_ACCESS_KEY_ID'],
-                    aws_secret_access_key = self.app.config['AWS_SECRET_ACCESS_KEY'],
-                )
+                kwargs = {
+                    'aws_access_key_id': self.app.config['AWS_ACCESS_KEY_ID'],
+                    'aws_secret_access_key': self.app.config['AWS_SECRET_ACCESS_KEY'],
+                    'host': self.app.config['DYNAMO_LOCAL_HOST'] if self.app.config['DYNAMO_ENABLE_LOCAL'] else None,
+                    'port': int(self.app.config['DYNAMO_LOCAL_PORT']) if self.app.config['DYNAMO_ENABLE_LOCAL'] else None,
+                    'is_secure': False if self.app.config['DYNAMO_ENABLE_LOCAL'] else True,
+                }
+
+                # If DynamoDB local is disabled, we'll remove these settings.
+                if not kwargs['host']:
+                    del kwargs['host']
+                if not kwargs['port']:
+                    del kwargs['port']
+
+                ctx.dynamo_connection = connect_to_region(self.app.config['AWS_REGION'], **kwargs)
 
             return ctx.dynamo_connection
 

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -33,6 +33,7 @@ class Dynamo(object):
 
         :param obj app: The Flask application.
         """
+        self.app = app
         self.init_settings()
         self.check_settings()
 

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -54,9 +54,6 @@ class Dynamo(object):
 
         :raises: ConfigurationError
         """
-        if not self.app.config['DYNAMO_TABLES']:
-            raise ConfigurationError('You must specify at least one Dynamo table to use.')
-
         if self.app.config['AWS_ACCESS_KEY_ID'] and not self.app.config['AWS_SECRET_ACCESS_KEY']:
             raise ConfigurationError('You must specify AWS_SECRET_ACCESS_KEY if you are specifying AWS_ACCESS_KEY_ID.')
 

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -1,18 +1,64 @@
 """Main Flask integration."""
 
-
 from os import environ
 
 from boto3.session import Session
-from flask import (
-    _app_ctx_stack as stack,
-)
+from flask import current_app
 
 from .errors import ConfigurationError
 
 
+class DynamoLazyTables(object):
+    """Manages access to Dynamo Tables."""
+    def __init__(self, connection, table_config):
+        self._table_config = table_config
+        self._connection = connection
+
+    def __getitem__(self, name):
+        """Get the connection for a table by name."""
+        return self._connection.Table(name)
+
+    def keys(self):
+        """The table names in our config."""
+        return [t['TableName'] for t in self._table_config]
+
+    def len(self):
+        """The number of tables we are configured for."""
+        return len(self.keys())
+
+    def items(self):
+        """The table tuples (name, connection.Table())."""
+        for table_name in self.keys():
+            yield (table_name, self[table_name])
+
+    def _wait(self, table_name, type_waiter):
+        waiter = self._connection.meta.client.get_waiter(type_waiter)
+        waiter.wait(TableName=table_name)
+
+    def wait_exists(self, table_name):
+        self._wait(table_name, 'table_exists')
+
+    def wait_not_exists(self, table_name):
+        self._wait(table_name, 'table_not_exists')
+
+    def create_all(self, wait=False):
+        for table in self._table_config:
+            self._connection.create_table(**table)
+        if wait:
+            for table in self._table_config:
+                self.wait_exists(table['TableName'])
+
+    def destroy_all(self, wait=False):
+        for table in self._table_config:
+            table = self._connection.Table(table['TableName'])
+            table.delete()
+        if wait:
+            for table in self._table_config:
+                self.wait_not_exists(table['TableName'])
+
+
 class Dynamo(object):
-    """DynamoDB wrapper for Flask."""
+    """DynamoDB engine manager."""
 
     DEFAULT_REGION = 'us-east-1'
 
@@ -32,21 +78,28 @@ class Dynamo(object):
 
         :param obj app: The Flask application.
         """
-        self.app = app
-        self.init_settings()
-        self.check_settings()
 
-    def init_settings(self):
+        self._init_settings(app)
+        self._check_settings(app)
+
+        app.extensions['dynamo'] = self
+
+        self.tables = DynamoLazyTables(self.connection, app.config['DYNAMO_TABLES'])
+
+    @staticmethod
+    def _init_settings(app):
         """Initialize all of the extension settings."""
-        self.app.config.setdefault('DYNAMO_TABLES', [])
-        self.app.config.setdefault('DYNAMO_ENABLE_LOCAL', environ.get('DYNAMO_ENABLE_LOCAL', False))
-        self.app.config.setdefault('DYNAMO_LOCAL_HOST', environ.get('DYNAMO_LOCAL_HOST'))
-        self.app.config.setdefault('DYNAMO_LOCAL_PORT', environ.get('DYNAMO_LOCAL_PORT'))
-        self.app.config.setdefault('AWS_ACCESS_KEY_ID', environ.get('AWS_ACCESS_KEY_ID'))
-        self.app.config.setdefault('AWS_SECRET_ACCESS_KEY', environ.get('AWS_SECRET_ACCESS_KEY'))
-        self.app.config.setdefault('AWS_REGION', environ.get('AWS_REGION', self.DEFAULT_REGION))
+        app.config.setdefault('DYNAMO_TABLES', [])
+        app.config.setdefault('DYNAMO_ENABLE_LOCAL', environ.get('DYNAMO_ENABLE_LOCAL', False))
+        app.config.setdefault('DYNAMO_LOCAL_HOST', environ.get('DYNAMO_LOCAL_HOST'))
+        app.config.setdefault('DYNAMO_LOCAL_PORT', environ.get('DYNAMO_LOCAL_PORT'))
+        app.config.setdefault('AWS_ACCESS_KEY_ID', environ.get('AWS_ACCESS_KEY_ID'))
+        app.config.setdefault('AWS_SECRET_ACCESS_KEY', environ.get('AWS_SECRET_ACCESS_KEY'))
+        app.config.setdefault('AWS_SESSION_TOKEN', environ.get('AWS_SESSION_TOKEN'))
+        app.config.setdefault('AWS_REGION', environ.get('AWS_REGION', Dynamo.DEFAULT_REGION))
 
-    def check_settings(self):
+    @staticmethod
+    def _check_settings(app):
         """
         Check all user-specified settings to ensure they're correct.
 
@@ -54,14 +107,43 @@ class Dynamo(object):
 
         :raises: ConfigurationError
         """
-        if self.app.config['AWS_ACCESS_KEY_ID'] and not self.app.config['AWS_SECRET_ACCESS_KEY']:
+        if app.config['AWS_ACCESS_KEY_ID'] and not app.config['AWS_SECRET_ACCESS_KEY']:
             raise ConfigurationError('You must specify AWS_SECRET_ACCESS_KEY if you are specifying AWS_ACCESS_KEY_ID.')
 
-        if self.app.config['AWS_SECRET_ACCESS_KEY'] and not self.app.config['AWS_ACCESS_KEY_ID']:
+        if app.config['AWS_SECRET_ACCESS_KEY'] and not app.config['AWS_ACCESS_KEY_ID']:
             raise ConfigurationError('You must specify AWS_ACCESS_KEY_ID if you are specifying AWS_SECRET_ACCESS_KEY.')
 
-        if self.app.config['DYNAMO_ENABLE_LOCAL'] and not (self.app.config['DYNAMO_LOCAL_HOST'] and self.app.config['DYNAMO_LOCAL_PORT']):
+        if app.config['DYNAMO_ENABLE_LOCAL'] and not (app.config['DYNAMO_LOCAL_HOST'] and app.config['DYNAMO_LOCAL_PORT']):
             raise ConfigurationError('If you have enabled Dynamo local, you must specify the host and port.')
+
+    def _get_app(self):
+        """
+        Helper method that implements the logic to look up an application.
+        pass
+        """
+        if current_app:
+            return current_app
+
+        if self.app is not None:
+            return self.app
+
+        raise RuntimeError(
+            'application not registered on dynamo instance and no application'
+            'bound to current context'
+        )
+
+    @staticmethod
+    def _get_ctx(app):
+        """
+        Gets the dyanmo app context state.
+        """
+
+        try:
+            return app.extensions['dynamo']
+        except KeyError:
+            raise RuntimeError(
+                'flask-dynamo extension not registered on flask app'
+            )
 
     @property
     def connection(self):
@@ -71,88 +153,48 @@ class Dynamo(object):
         This will be lazily created if this is the first time this is being
         accessed.  This connection is reused for performance.
         """
-        ctx = stack.top
-        if ctx is not None:
-            if not hasattr(ctx, 'dynamo_connection'):
-                session_kwargs = {}
-                client_kwargs = {}
-                local = True if self.app.config['DYNAMO_ENABLE_LOCAL'] else False
-                if local:
-                    client_kwargs['endpoint_url'] = 'http://{}:{}'.format(
-                        self.app.config['DYNAMO_LOCAL_HOST'],
-                        self.app.config['DYNAMO_LOCAL_PORT'],
-                    )
+        app = self._get_app()
+        ctx = self._get_ctx(app)
+        try:
+            return ctx._connection
+        except AttributeError:
+            session_kwargs = {}
+            client_kwargs = {}
+            local = True if app.config['DYNAMO_ENABLE_LOCAL'] else False
+            if local:
+                client_kwargs['endpoint_url'] = 'http://{}:{}'.format(
+                    app.config['DYNAMO_LOCAL_HOST'],
+                    app.config['DYNAMO_LOCAL_PORT'],
+                )
 
-                # Only apply if manually specified: otherwise, we'll let boto
-                # figure it out (boto will sniff for ec2 instance profile
-                # credentials).
-                if self.app.config['AWS_ACCESS_KEY_ID']:
-                    session_kwargs['aws_access_key_id'] = self.app.config['AWS_ACCESS_KEY_ID']
-                if self.app.config['AWS_SECRET_ACCESS_KEY']:
-                    session_kwargs['aws_secret_access_key'] = self.app.config['AWS_SECRET_ACCESS_KEY']
-                if self.app.config.get('AWS_REGION', None):
-                    session_kwargs['region_name'] = self.app.config['AWS_REGION']
+            # Only apply if manually specified: otherwise, we'll let boto
+            # figure it out (boto will sniff for ec2 instance profile
+            # credentials).
+            if app.config['AWS_ACCESS_KEY_ID']:
+                session_kwargs['aws_access_key_id'] = app.config['AWS_ACCESS_KEY_ID']
+            if app.config['AWS_SECRET_ACCESS_KEY']:
+                session_kwargs['aws_secret_access_key'] = app.config['AWS_SECRET_ACCESS_KEY']
+            if app.config.get('AWS_SESSION_TOKEN', None):
+                session_kwargs['aws_session_token'] = app.config['AWS_SESSION_TOKEN']
+            if app.config.get('AWS_REGION', None):
+                session_kwargs['region_name'] = app.config['AWS_REGION']
 
-                ctx.dynamo_session = Session(**session_kwargs)
-                ctx.dynamo_connection = ctx.dynamo_session.resource('dynamodb', **client_kwargs)
+            ctx._session = Session(**session_kwargs)
+            ctx._connection = ctx._session.resource('dynamodb', **client_kwargs)
 
-            return ctx.dynamo_connection
-
-    @property
-    def tables(self):
-        """
-        Our DynamoDB tables.
-
-        These will be lazily initializes if this is the first time the tables
-        are being accessed.
-        """
-        ctx = stack.top
-        if ctx is not None:
-            if not hasattr(ctx, 'dynamo_tables'):
-                ctx.dynamo_tables = {}
-                for table in self.app.config['DYNAMO_TABLES']:
-                    table_name = table['TableName']
-                    ctx.dynamo_tables[table_name] = table
-
-                    if not hasattr(ctx, 'dynamo_table_%s' % table_name):
-                        setattr(ctx, 'dynamo_table_%s' % table_name, table)
-
-            return ctx.dynamo_tables
-
-    def __getattr__(self, name):
-        """
-        Override the get attribute built-in method.
-
-        This will allow us to provide a simple table API.  Let's say a user
-        defines two tables: `users` and `groups`.  In this case, our
-        customization here will allow the user to access these tables by calling
-        `dynamo.users` and `dynamo.groups`, respectively.
-
-        :param str name: The DynamoDB table name.
-        :rtype: object
-        :returns: A Table object if the table was found.
-        :raises: AttributeError on error.
-        """
-        if name in self.tables:
-            return self.get_table(name)
-
-        raise AttributeError('No table named %s found.' % name)
+            return ctx._connection
 
     def get_table(self, table_name):
-        return self.connection.Table(table_name)
+        return self.tables[table_name]
 
     def create_all(self, wait=False):
         """
         Create all user-specified DynamoDB tables.
 
+        We'll ignore table(s) that already exists.
         We'll error out if the tables can't be created for some reason.
         """
-        for table_name in self.tables:
-            table = self.tables[table_name]
-            self.connection.create_table(**table)
-            if wait:
-                waiter = self.connection.meta.client.get_waiter('table_exists')
-                waiter.wait(TableName=table['TableName'])
+        self.tables.create_all(wait=wait)
 
     def destroy_all(self, wait=False):
         """
@@ -160,9 +202,4 @@ class Dynamo(object):
 
         We'll error out if the tables can't be destroyed for some reason.
         """
-        for table_name in self.tables:
-            table = self.connection.Table(table_name)
-            table.delete()
-            if wait:
-                waiter = self.connection.meta.client.get_waiter('table_not_exists')
-                waiter.wait(TableName=table['TableName'])
+        self.tables.destroy_all(wait=wait)

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -11,9 +11,6 @@ from flask import (
 
 from .errors import ConfigurationError
 
-import logging
-
-logger = logging.getLogger(__name__)
 
 class Dynamo(object):
     """DynamoDB wrapper for Flask."""
@@ -60,11 +57,6 @@ class Dynamo(object):
         if not self.app.config['DYNAMO_TABLES']:
             raise ConfigurationError('You must specify at least one Dynamo table to use.')
 
-        if not self.app.config['AWS_ACCESS_KEY_ID'] and not self.app.config['AWS_SECRET_ACCESS_KEY']:
-            logger.warning('No AWS credentials specified; continuing in the hope '
-                    'that the boto default credentials provider finds an ec2 '
-                    'instance profile.')
-
         if self.app.config['AWS_ACCESS_KEY_ID'] and not self.app.config['AWS_SECRET_ACCESS_KEY']:
             raise ConfigurationError('You must specify AWS_SECRET_ACCESS_KEY if you are specifying AWS_ACCESS_KEY_ID.')
 
@@ -91,8 +83,9 @@ class Dynamo(object):
                     'is_secure': False if self.app.config['DYNAMO_ENABLE_LOCAL'] else True,
                 }
 
-                # only apply if manually specified; otherwise let boto figure it out
-                # (boto will sniff for ec2 instance profile credentials)
+                # Only apply if manually specified: otherwise, we'll let boto
+                # figure it out (boto will sniff for ec2 instance profile
+                # credentials).
                 if self.app.config['AWS_ACCESS_KEY_ID']:
                   kwargs['aws_access_key_id'] = self.app.config['AWS_ACCESS_KEY_ID']
                 if self.app.config['AWS_SECRET_ACCESS_KEY']:

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -42,11 +42,14 @@ class DynamoLazyTables(object):
         self._wait(table_name, 'table_not_exists')
 
     def create_all(self, wait=False):
+        tables_name_list = [table.name for table in self._connection.tables.all()]
         for table in self._table_config:
-            self._connection.create_table(**table)
+            if table['TableName'] not in tables_name_list:
+                self._connection.create_table(**table)
         if wait:
             for table in self._table_config:
-                self.wait_exists(table['TableName'])
+                if table['TableName'] not in tables_name_list:
+                    self.wait_exists(table['TableName'])
 
     def destroy_all(self, wait=False):
         for table in self._table_config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask>=0.10.1
 Sphinx==1.2.2
-boto>=2.29.1
-pytest==2.5.2
+boto3>=1.1.4
+pytest>=2.5.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.5'
+VERSION = '0.0.6'
 
 
 class RunTests(Command):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 
 
 class RunTests(Command):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.7'
+VERSION = '0.1.0'
 
 
 class RunTests(Command):
@@ -32,8 +32,9 @@ class RunTests(Command):
 
     def run(self):
         """Run all tests!"""
-        errno = call(['py.test'])
-        raise SystemExit(errno)
+        import sys
+        import py.test
+        raise SystemExit(py.test.main(args=[]))
 
 
 setup(
@@ -48,7 +49,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['boto>=2.29.1', 'Flask>=0.10.1'],
+    install_requires = ['boto3>=1.1.4', 'Flask>=0.10.1'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',
@@ -73,6 +74,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 
 
 class RunTests(Command):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.0.6'
+VERSION = '0.0.7'
 
 
 class RunTests(Command):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,13 +3,11 @@ from __future__ import print_function
 
 
 from os import environ
-from time import sleep
-from unittest import TestCase
 from uuid import uuid4
 
 import pytest
-from flask import Flask
-from flask.ext.dynamo import Dynamo, ConfigurationError
+from flask import Flask, current_app
+from flask_dynamo import Dynamo, ConfigurationError
 
 def make_table(table_name, name, _type):
     return dict(
@@ -89,11 +87,9 @@ def test_connection(app, dynamo):
         assert hasattr(dynamo.connection, 'meta')
         assert hasattr(dynamo.connection.meta, 'client')
 
-def test_tables(app, active_dynamo):
-    with app.app_context():
-        assert len(active_dynamo.tables.keys()) == 2
-
 def test_table_access(active_dynamo, app):
     with app.app_context():
+        assert len(active_dynamo.tables.keys()) == 2
         for table_name, table in active_dynamo.tables.items():
-            assert getattr(active_dynamo, table_name).name == table_name
+            assert active_dynamo.tables[table_name].name == table_name
+            assert current_app.extensions['dynamo'].tables[table_name].name == table_name


### PR DESCRIPTION
https://github.com/rdegges/flask-dynamo/pull/21

There is a lot in here:

support app factory and traditional method
refactoring of tables to a table manager object. This was to avoid messiness in circular references
breaking change: dynamo.table_name no longer supported. The getattr would not play nice at all on python3. For now, i dropped support for this feature, but if you know of a way to reincorporate, I am more than happy to try and include it.
merge conflicts between the dev branch and the current master were resolved
github .gitignore file now included (there were python3 files that were not being ignored)
docs updated to match boto3, as well as updated apis.
minor test refactoring to make tests faster
Issues addressed:

fixes: #13
fixes: #10
fixes: #16