### PR TITLE
Develop to master

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,17 @@ Change Log
 
 All library changes, in descending order.
 
-Version 0.1.0
+Version 0.1.1
 -------------
 
 **Not yet released.**
+
+- Added support for shared boto3 session.
+
+Version 0.1.0
+-------------
+
+**Released on August 21, 2017.**
 
 - Added support for flask app factory and traditional methods of initialization.
 - Added documentation for boto3.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,12 +6,14 @@ Change Log
 
 All library changes, in descending order.
 
+
 Version 0.1.1
 -------------
 
-**Not yet released.**
+**Released on August 21, 2017.**
 
 - Added support for shared boto3 session.
+
 
 Version 0.1.0
 -------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,9 @@ Version 0.1.0
 
 - Added support for flask app factory and traditional methods of initialization.
 - Added documentation for boto3.
-- Fixed reuse of dynamodb connections across requests.
+- Fixed reuse of DynamoDB connections across requests.
 - Optimized tests to run faster.
-- Added support for AWS_SESSION_TOKEN.  Thanks `@vbisserie
+- Added support for ``AWS_SESSION_TOKEN``.  Thanks `@vbisserie
   <https://github.com/vbisserie>`_ for the code!
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'flask-dynamo'
-copyright = u'2014, Randall Degges'
+copyright = u'2017, Randall Degges'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -254,3 +254,22 @@ No other code needs to be changed in order to use DynamoDB Local.
 .. _StackOverflow question: http://stackoverflow.com/questions/5971312/how-to-set-environment-variables-in-python
 .. _boto DynamoDB tutorial: http://boto3.readthedocs.io/en/latest/guide/dynamodb.html
 .. _DynamoDB Local documentation: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
+
+
+Specifying boto3 session
+------------------------
+
+If you would like to specify the boto3 session that Flask-dynamo should use,
+you can specify it by providing the boto3 session in the app config. This is
+optional, and if you don't specify a session, flask-dynamo will create one for
+you. This may be useful if you want to reuse the boto3 session with multiple
+plugins.
+
+- ``DYNAMO_SESSION`` - *optional* Sets the boto3 session that flask-dynamo
+  should use
+
+    from boto3.session import Session()
+    boto_sess = Session(region_name='us-east-1',
+                        aws_access_key_id='example_key_id',
+                        aws_secret_access_key='my_super_secret_key')
+    app.config['DYNAMO_SESSION'] = boto_sess

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -256,7 +256,7 @@ No other code needs to be changed in order to use DynamoDB Local.
 .. _DynamoDB Local documentation: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
 
 
-Specifying boto3 session
+Specifying boto3 Session
 ------------------------
 
 If you would like to specify the boto3 session that Flask-dynamo should use,
@@ -268,7 +268,9 @@ useful if you want to reuse the boto3 session with multiple plugins.
   should use. eg::
 
     from boto3.session import Session()
-    boto_sess = Session(region_name='us-east-1',
-                        aws_access_key_id='example_key_id',
-                        aws_secret_access_key='my_super_secret_key')
+    boto_sess = Session(
+        region_name='us-east-1',
+        aws_access_key_id='example_key_id',
+        aws_secret_access_key='my_super_secret_key'
+    )
     app.config['DYNAMO_SESSION'] = boto_sess

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -260,10 +260,9 @@ Specifying boto3 session
 ------------------------
 
 If you would like to specify the boto3 session that Flask-dynamo should use,
-you can specify it by providing the boto3 session in the app config. This is
-optional, and if you don't specify a session, flask-dynamo will create one for
-you. This may be useful if you want to reuse the boto3 session with multiple
-plugins.
+flask-dynamo has an option in the app config. This is optional, and if you
+don't specify a session, flask-dynamo will create one for you. This may be
+useful if you want to reuse the boto3 session with multiple plugins.
 
 - ``DYNAMO_SESSION`` - *optional* Sets the boto3 session that flask-dynamo
   should use. eg::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -238,7 +238,7 @@ The settings you need to set are:
 - ``DYNAMO_LOCAL_PORT`` - Set this to your local DB port -- usually ``8000``.
 
 The settings above can be specified in one of two ways, either via environment
-variables, or via application configuration options directly, eg:
+variables, or via application configuration options directly, eg::
 
     app.config['DYNAMO_ENABLE_LOCAL'] = True
     app.config['DYNAMO_LOCAL_HOST'] = 'localhost'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,6 +53,8 @@ If you're unsure of how to set environment variables, I recommend you check out
 this `StackOverflow question`_.
 
 
+.. _specify-your-tables:
+
 Specify Your Tables
 -------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -266,7 +266,7 @@ you. This may be useful if you want to reuse the boto3 session with multiple
 plugins.
 
 - ``DYNAMO_SESSION`` - *optional* Sets the boto3 session that flask-dynamo
-  should use
+  should use. eg::
 
     from boto3.session import Session()
     boto_sess = Session(region_name='us-east-1',

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -7,6 +7,12 @@ Upgrade Guide
 This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
+Version 0.1.0 -> Version 0.1.1
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.8 -> Version 0.1.0
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -7,6 +7,7 @@ Upgrade Guide
 This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
+
 Version 0.1.0 -> Version 0.1.1
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,12 @@ This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
 
+Version 0.0.7 -> Version 0.0.8
+------------------------------
+
+**No changes needed!**
+
+
 Version 0.0.6 -> Version 0.0.7
 ------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -10,13 +10,14 @@ flask-dynamo releases.
 Version 0.0.8 -> Version 0.1.0
 ------------------------------
 
-**Changes required!**
-* The app.config['DYNAMO_TABLES'] schema needs to be updated to boto3 style. See
-  :ref:`quickstart` for examples of how to do this.
-* **Note** boto3 is a new requirement.
-* **Optional** Use the app factory pattern, and access dynamo via
-  ``Flask.current_app.extensions['dynamodb']``
+**Changes required.**
 
+* The ``app.config['DYNAMO_TABLES']`` schema needs to be updated to `boto3
+  <https://boto3.readthedocs.io/en/latest/guide/dynamodb.html#creating-a-new-table>`_
+  style. See :ref:`Specify Your Tables <specify-your-tables>` for examples of
+  how to do this.
+* **OPTIONAL**: Use the app factory pattern, and access Dynamo via
+  ``Flask.current_app.extensions['dynamodb']``
 
 
 Version 0.0.7 -> Version 0.0.8

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -7,6 +7,17 @@ Upgrade Guide
 This page contains specific upgrading instructions to help you migrate between
 flask-dynamo releases.
 
+Version 0.0.8 -> Version 0.1.0
+------------------------------
+
+**Changes required!**
+* The app.config['DYNAMO_TABLES'] schema needs to be updated to boto3 style. See
+  :ref:`quickstart` for examples of how to do this.
+* **Note** boto3 is a new requirement.
+* **Optional** Use the app factory pattern, and access dynamo via
+  ``Flask.current_app.extensions['dynamodb']``
+
+
 
 Version 0.0.7 -> Version 0.0.8
 ------------------------------

--- a/flask_dynamo/manager.py
+++ b/flask_dynamo/manager.py
@@ -95,11 +95,11 @@ class Dynamo(object):
         app.config.setdefault('DYNAMO_SESSION', None)
         app.config.setdefault('DYNAMO_TABLES', [])
         app.config.setdefault('DYNAMO_ENABLE_LOCAL', environ.get('DYNAMO_ENABLE_LOCAL', False))
-        app.config.setdefault('DYNAMO_LOCAL_HOST', environ.get('DYNAMO_LOCAL_HOST'))
-        app.config.setdefault('DYNAMO_LOCAL_PORT', environ.get('DYNAMO_LOCAL_PORT'))
-        app.config.setdefault('AWS_ACCESS_KEY_ID', environ.get('AWS_ACCESS_KEY_ID'))
-        app.config.setdefault('AWS_SECRET_ACCESS_KEY', environ.get('AWS_SECRET_ACCESS_KEY'))
-        app.config.setdefault('AWS_SESSION_TOKEN', environ.get('AWS_SESSION_TOKEN'))
+        app.config.setdefault('DYNAMO_LOCAL_HOST', environ.get('DYNAMO_LOCAL_HOST', None))
+        app.config.setdefault('DYNAMO_LOCAL_PORT', environ.get('DYNAMO_LOCAL_PORT', None))
+        app.config.setdefault('AWS_ACCESS_KEY_ID', environ.get('AWS_ACCESS_KEY_ID', None))
+        app.config.setdefault('AWS_SECRET_ACCESS_KEY', environ.get('AWS_SECRET_ACCESS_KEY', None))
+        app.config.setdefault('AWS_SESSION_TOKEN', environ.get('AWS_SESSION_TOKEN', None))
         app.config.setdefault('AWS_REGION', environ.get('AWS_REGION', Dynamo.DEFAULT_REGION))
 
     @staticmethod
@@ -159,9 +159,9 @@ class Dynamo(object):
             session_kwargs['aws_access_key_id'] = app.config['AWS_ACCESS_KEY_ID']
         if app.config['AWS_SECRET_ACCESS_KEY']:
             session_kwargs['aws_secret_access_key'] = app.config['AWS_SECRET_ACCESS_KEY']
-        if app.config.get('AWS_SESSION_TOKEN', None):
+        if app.config['AWS_SESSION_TOKEN']:
             session_kwargs['aws_session_token'] = app.config['AWS_SESSION_TOKEN']
-        if app.config.get('AWS_REGION', None):
+        if app.config['AWS_REGION']:
             session_kwargs['region_name'] = app.config['AWS_REGION']
         return Session(**session_kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from subprocess import call
 from setuptools import Command, setup
 
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 
 class RunTests(Command):


### PR DESCRIPTION
This allows multiple flask extensions to reuse the same boto3 session. For instance, you may want to use this extension with https://github.com/mcrowson/flask-sessionstore, so that you have your flask session stored server side in DynamoDB.
TODO:

- [x] update docs