### PR TITLE
Update quickstart.rst - fix extension name

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -155,7 +155,7 @@ If you use the app factory pattern then use::
 
 
 From this point on, you can interact with DynamoDB through the global ``dynamo``
-object, or through ``Flask.current_app.extensions['dynamodb']`` if you are
+object, or through ``Flask.current_app.extensions['dynamo']`` if you are
 using the Flask app factory pattern.
 
 


### PR DESCRIPTION
The extension is named 'dynamo', not 'dynamodb', see https://github.com/rdegges/flask-dynamo/blob/0.1.2/flask_dynamo/manager.py#L88