### PR TITLE
Fixing syntax error in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -75,17 +75,17 @@ Below is an example::
 
     app = Flask(__name__)
     app.config['DYNAMO_TABLES'] = [
-        {
+        dict(
              TableName='users',
              KeySchema=[dict(AttributeName='username', KeyType='HASH')],
              AttributeDefinitions=[dict(AttributeName='username', AttributeType='S')],
              ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
-        }, {
+        ), dict(
              TableName='groups',
              KeySchema=[dict(AttributeName='name', KeyType='HASH')],
              AttributeDefinitions=[dict(AttributeName='name', AttributeType='S')],
              ProvisionedThroughput=dict(ReadCapacityUnits=5, WriteCapacityUnits=5)
-        }
+        )
      ]
 
 In the above example, I'm defining two DynamoDB tables: ``users`` and


### PR DESCRIPTION
This small bug is documented in Issue#41 (https://github.com/rdegges/flask-dynamo/issues/41), this is a quick PR to remedy this.